### PR TITLE
Add ability to keep comments. It still strips them by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the node.js version of [premailer](http://premailer.dialect.ca/).
 ### Features
 
 - Copies `<style />`, and `<link />` data to associated elements.
-- Strips out comments.
+- Strips out comments by default, but you can optionally keep them, this is useful if you intend to use VML to provide background-images.
 - HTML compatibility checking for popular email clients. See:
 	- http://www.campaignmonitor.com/css/
 	- http://www.campaignmonitor.com/downloads/documents-tools/campaign-monitor-guide-to-css-in-email-sept-2011.pdf
@@ -65,15 +65,21 @@ npm install emailify -g
 -i [input_html] -o [output_html]
 
 Options:
-  -i, --input   [required]
+  -i, --input    [required]
   -o, --output  
-  -t, --test    [default: false]
+  -t, --test     [default: false]
+  -c, --comments [default: false]
 ```
 
 To emailify a document, use this command:
 
 ```bash
 emailify -i /my/html/file.html -o /my/html/emailified.html
+```
+If you intend to keep comments, do the following:
+
+```bash
+emailify -c true -i /my/html/file.html -o /my/html/emailified.html
 ```
 
 You can easily test a document for compatibility by adding the `-t` flag:

--- a/bin/emailify
+++ b/bin/emailify
@@ -5,10 +5,14 @@ usage('-i [input_html] -o [output_html]').
 demand('i').
 default('o').
 default('t', false).
+default('c', false).
 alias('i','input').
 alias('o','output').
 alias('t','test').
+alias('c','comments').
 argv;
+
+
 
 var fs   = require('fs'),
 emailify = require('../'),
@@ -19,7 +23,6 @@ celeri   = require('celeri');
  */
 
 function fixFile(file) {
-
 	return file.replace(/^\.\//,process.cwd() + '/').replace(/^\~/,process.env.HOME);
 
 }
@@ -37,7 +40,7 @@ var on = outcome.error(function(err) {
  */
 
 
-emailify.load(fixFile(argv.i), { test: argv.t }, on.success(function(content, warnings) {
+emailify.load(fixFile(argv.i), { test: argv.t , comments: argv.c }, on.success(function(content, warnings) {
 
 	if(argv.o) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ function _copyStyles(window) {
 				element.style.cssText += rule.style.cssText;
 				element.cssText        = element.style.cssText;
 
-			}); 
+			});
 		} catch(e) {
 
 		}
@@ -100,12 +100,14 @@ function _parse(content, options, callback) {
 			//strip stuff that cannot be processed
 			window.$('script, link, style').remove();
 
-			//strip comments - sometimes gets rendered
-			window.$('*').contents().each(function(node) {
-				if(this.nodeType == 8) {
-					window.$(this).remove();
-				}
-			});
+            if (!options.comments) {
+                //strip comments - sometimes gets rendered
+                window.$('*').contents().each(function(node) {
+                    if(this.nodeType == 8) {
+                        window.$(this).remove();
+                    }
+                });
+            }
 
 			this();
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "plugin": "0.0.x",
         "step": "0.0.x",
         "colors": "0.6.x",
-        "sprintf": "0.1.x"
+        "sprintf": "0.1.x",
+        "celeri": "0.2.x"
     },
     "devDependencies": {},
     "bin": {


### PR DESCRIPTION
- Newer clients like Outlook 2007-2013, unfortunately, render emails
  with Word, and comments are needed to provide background-images.
  [check here for more info](http://www.campaignmonitor.com/blog/post/3363/updated-applying-a-background-image-to-html-email/).  
  So I've added an extra option `-c` to indicate, when true, that
  comments should not be removed. This option is false by default.
- Celeri was not declared in the package.json as a dependency, making the
  binary throw errors when it was used. This was fixed.
- Update README.md with the `-c, --comments` option.
